### PR TITLE
Remove wording to inform rustc about "ar"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ $ rm -r tmp
 $ mkdir -p ~/.cargo
 $ cat >>~/.cargo/config <<EOF
 > [target.arm-unknown-linux-gnueabihf]
-> ar = "arm-linux-gnueabihf-ar"
 > linker = "arm-linux-gnueabihf-gcc"
 > EOF
 
@@ -318,8 +317,6 @@ Cross compiling with `rustc` only requires passing a few extra flags to its invo
 - `--target=$rustc_target`, tells `rustc` we are cross compiling for `$rustc_target`.
 - `-C linker=$gcc_prefix-gcc`, instructs `rustc` to use a cross linker instead of the native one
     (`cc`).
-- `-C ar=$gcc_prefix-ar`, instructs `rustc` to use a cross archiver instead of the native one
-   (`ar`).
 
 Next, an example to test the cross compilation setup so far:
 
@@ -338,7 +335,6 @@ fn main() {
 $ rustc \
     --target=arm-unknown-linux-gnueabihf \
     -C linker=arm-linux-gnueabihf-gcc \
-    -C ar=arm-linux-gnueabihf-gcc \
     hello.rs
 ```
 
@@ -391,7 +387,6 @@ clap = "2.0.4"
 $ mkdir .cargo
 $ cat >.cargo/config <<EOF
 > [target.arm-unknown-linux-gnueabihf]
-> ar = "arm-linux-gnueabihf-ar"
 > linker = "arm-linux-gnueabihf-gcc"
 > EOF
 ```

--- a/README.md
+++ b/README.md
@@ -353,8 +353,8 @@ and archiver for the target. Once set, we only need to pass the `--target` flag 
 
 [configuration system]: http://doc.crates.io/config.html
 
-Cargo configuration is stored in a TOML file, the keys we are interested in are
-`target.$rustc_target.ar` and `target.$rustc_target.linker`. The values to store in these keys are
+Cargo configuration is stored in a TOML file, the key we are interested in is
+`target.$rustc_target.linker`. The value to store in this key is
 the same we passed to `rustc` in the previous section. It's up to you to decide if you make this
 configuration global or project specific.
 


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/26926 the compiler never actually spawns an `ar` process, and the LLVM implementation handles all format details, so there's actually no need to tell the compiler about this tool any more!
